### PR TITLE
Add circle centered near Bandundu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -246,6 +246,11 @@
                         fillOpacity: 0,
                         radius: 120000
                     }).addTo(map);
+                    L.circle([-3.3446160, 17.3831338], {
+                        color: 'blue',
+                        fillOpacity: 0,
+                        radius: 120000
+                    }).addTo(map);
                 });
             }
             if (!map) {


### PR DESCRIPTION
## Summary
- add additional circle on the map centered at (-3.3446160, 17.3831338)

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68babf1c14d483208b3bc9b55d410e0a